### PR TITLE
Fix reactive values in UserHeader

### DIFF
--- a/src/lib/components/users/UserHeader.svelte
+++ b/src/lib/components/users/UserHeader.svelte
@@ -1,21 +1,13 @@
-<script lang="ts" context="module">
-    export const defaults: User = {
-        hexpubkey: "",
-        npub: "",
-        loading: true,
-    };
-</script>
-
 <script lang="ts">
     import { getName, type User } from "./type";
 
-    export let user: User = defaults;
-    let { profile, hexpubkey, loading } = user;
-    let display_name = "";
-    $: {
-        let { profile, hexpubkey, loading } = user;
-        display_name = getName(user);
-    }
+    export let user: User = {
+        hexpubkey: "",
+        npub: "",
+        loading: true,
+        };
+    $: ({ profile, loading } = user);
+    $: display_name = getName(user);
 </script>
 
 <div class="flex my-2">
@@ -25,8 +17,8 @@
             class:skeleton={!profile && loading}
             class:bg-neutral={!loading && (!profile || !profile.image)}
         >
-            {#if profile && profile.image}
-                <img class="my-0" src={profile.image} alt={display_name} />
+            {#if !!profile?.image}
+                <img class="my-0" src={profile?.image} alt={display_name} />
             {/if}
         </div>
     </div>


### PR DESCRIPTION
BEFORE:

Image of maintainers does not update while switching details

[before.webm](https://github.com/DanConwayDev/gitworkshop/assets/47693/1224e61a-cb88-4e5f-8709-3c062cf7c3cb)


FIX:

[after.webm](https://github.com/DanConwayDev/gitworkshop/assets/47693/04862b8c-4225-4eab-99ca-5631f2c3fd81)


See "Example of Reactively Destructuring Variables" in Svelte https://daveceddia.com/svelte-reactive-destructuring/